### PR TITLE
Fixed regex test script

### DIFF
--- a/regex_test.ps1
+++ b/regex_test.ps1
@@ -19,13 +19,22 @@
 [System.Collections.ArrayList]$TestData = @()
 $TestData += Import-Csv -Path "$($PSScriptRoot)\testdata.csv" | Where-Object -FilterScript {$_.String} #Filter out blank lines
 
-Describe "$($Pattern.ToString())"{    
-    Foreach($Test in $TestData){      
-        $ShouldMatch = [Boolean][int]$Test.ShouldMatch
-        [String]$Verb = if($ShouldMatch){'Matches'}Else{'Ignores'}
-
-        It "$($Verb) '$($Test.String)'"{
-            $Pattern.Match($Test.String).Success | Should -Be $ShouldMatch
-        }
+Foreach($Test in $TestData){      
+    $ShouldMatch = [Boolean][int]$Test.ShouldMatch
+    
+    if($ShouldMatch){
+        [String]$Verb = 'Matches'
     }
+    Else{
+        [String]$Verb = 'Ignores'
+    }
+
+    if($Pattern.Match($Test.String).Success -eq $ShouldMatch){
+        $ForegroundColor = 'Green'
+    }
+    else{
+        $ForegroundColor = 'Red'
+    }
+
+    Write-Host -Object "$($Verb) '$($Test.String)'" -ForegroundColor $ForegroundColor
 }

--- a/regex_test.ps1
+++ b/regex_test.ps1
@@ -1,5 +1,5 @@
 <#
-    This script will use the pester unit testing framework in PowerShell to verify a given regex pattern vs test data.
+    This script will verify a given regex pattern vs test data.
 
     This will execute the tests via the .Net regex engine so keep in mind it might not be a perfect port to your given language
     as not all parts of the engine are supported universally. Ex: negative lookahead is supported in .Net but not Go.
@@ -10,9 +10,7 @@
     i11in0is.mydomain.site,1
 
     While pattern.txt is just a single line txt file containing your pattern.
-    Both of these files should be in the same directory as this script.
-
-    The script can be executed by being called directly or by having it inside your working directory and running "Invoke-Pester"   
+    Both of these files should be in the same directory as this script. 
 #>
 
 [regex]$Pattern = (Get-Content -Path "$($PSScriptRoot)\pattern.txt")


### PR DESCRIPTION
The regex testing script broke with Pester 5. Instead of spending an afternoon figuring out how to get it working in pester 5 I just changed it to print out red/green text which is functionally the same.